### PR TITLE
Add json_serializer unit test

### DIFF
--- a/tests/test_kafka_api.py
+++ b/tests/test_kafka_api.py
@@ -1,0 +1,20 @@
+import sys
+import os
+import types
+
+# Ensure the project root is on sys.path so kafkaApi can be imported
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Create a dummy kafka module with KafkaProducer to avoid import errors
+kafka_dummy = types.ModuleType('kafka')
+class DummyProducer:
+    def __init__(self, *args, **kwargs):
+        pass
+kafka_dummy.KafkaProducer = DummyProducer
+sys.modules.setdefault('kafka', kafka_dummy)
+
+from kafkaApi import json_serializer
+
+
+def test_json_serializer_bytes():
+    assert json_serializer({"a": 1}) == b'{"a": 1}'


### PR DESCRIPTION
## Summary
- add a pytest verifying `json_serializer` output
- ensure test imports `kafkaApi` without Kafka installed by patching `sys.modules`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d60d34d1c8331a6c777656a39d23a