### PR TITLE
Fix option name in comment

### DIFF
--- a/clickhouseConsumer.py
+++ b/clickhouseConsumer.py
@@ -20,7 +20,7 @@ And that's exactly what we want here.
 
 enable_auto_commit = True:makes sure the consumer commits its read offset every interval.
 
-auto_commit interval_ms = 1000ms:sets the interval between two commits.
+auto_commit_interval_ms = 1000ms:sets the interval between two commits.
 Since messages are coming in every five second,committing every second seems fair.
 
 group_id = 'counters':this is the consumer group to which the consumer belongs.


### PR DESCRIPTION
## Summary
- fix comment to reference `auto_commit_interval_ms`

## Testing
- `python3 -m py_compile clickhouseConsumer.py`


------
https://chatgpt.com/codex/tasks/task_e_684d60cb2a788331b98d1e0de311383b